### PR TITLE
Fix infinite loop if controller has no name

### DIFF
--- a/source/lib/GC_Layouts.js
+++ b/source/lib/GC_Layouts.js
@@ -31,6 +31,7 @@ const GC_Layouts = {
     },
 
     has: function(name) {
+        if (!name) return false;
         name = name.toLowerCase();
         return name in Controller.layouts.list;
     },


### PR DESCRIPTION
My controller does not have a name but does include an `.id` called `Microsoft X-Box 360 pad`.
This is a quick fix to stop an infinite loop from occurring.

The console error I get is:
```
TypeError: undefined is not an object (evaluating 'name.toLowerCase')
```